### PR TITLE
version0.1.0におけるバグフィックスと機能追加

### DIFF
--- a/library/harbor3d/dock.py
+++ b/library/harbor3d/dock.py
@@ -27,7 +27,7 @@ class Dock:
     def get_child_ship(self, parent_ship):
         childs = []
         for ship in self.ships:
-            if ship.parent == parent_ship:
+            if ship.parent is parent_ship:
                 childs.append(ship)
         return childs
 

--- a/library/harbor3d/ship.py
+++ b/library/harbor3d/ship.py
@@ -50,6 +50,12 @@ class Ship:
         self.parents.extend(self.parent.get_parents())
         self.parents.append(self.parent)
         return self.parents
+    
+    def is_contains_in_parents(self, target_ship):
+        for ship in self.parents:
+            if ship is target_ship:
+                return True
+        return False
 
     def end(self, child):
         child.end = self

--- a/library/harbor3d/util/edges_util.py
+++ b/library/harbor3d/util/edges_util.py
@@ -20,6 +20,10 @@ def size(edges):
             y_max = edge[1]
     return ((x_min, x_max),(y_min, y_max))
 
+def length(edges):
+    ((x_min, x_max),(y_min, y_max)) = size(edges)
+    return (x_max-x_min, y_max-y_min)
+
 def scale(edges, scale):
     if scale is None:
         return edges

--- a/library/harbor3d/util/load_util.py
+++ b/library/harbor3d/util/load_util.py
@@ -6,7 +6,7 @@ import subprocess
 
 from harbor3d.util import model_util
 
-def load_binary_stl(path):
+def load_binary_stl(path, vertex_matching=True):
     with open(path, "rb") as f:
         read_block = f.read(80) # discard
         read_block = f.read(4) # discard
@@ -29,13 +29,20 @@ def load_binary_stl(path):
 
             triangle = []
             for vertex in vertexes:
-                vertex_esists = [x for x in positions if x.position[0] == vertex[0] and x.position[1] == vertex[1] and x.position[2] == vertex[2]]
-                if (0 == len (vertex_esists)):
+                if vertex_matching:
+                    # finally, (number of positions) < 3 * (number of triangles)
+                    vertex_esists = [x for x in positions if x.position[0] == vertex[0] and x.position[1] == vertex[1] and x.position[2] == vertex[2]]
+                    if (0 == len (vertex_esists)):
+                        position = model_util.Position(vertex)
+                        positions.append(position)
+                        triangle.append(position)
+                    else:
+                        triangle.append(vertex_esists[0])
+                else:
+                    # finally, (number of positions) == 3 * (number of triangles)
                     position = model_util.Position(vertex)
                     positions.append(position)
                     triangle.append(position)
-                else:
-                    triangle.append(vertex_esists[0])
             triangles.append(model_util.Triangle(triangle[0], triangle[1], triangle[2]))
             
         return model_util.MonocoqueShell(positions, triangles)
@@ -83,9 +90,10 @@ def load_huge_binary_stl(path):
             positions.extend(positions_value)
         return model_util.MonocoqueShell(positions, triangles)
 
-def load_submodule(path, force_load_merged_stl):
+def load_submodule(path, force_load_merged_stl, vertex_matching=True):
     if not os.path.isdir(path):
         raise Exception("submodule is not a path")
+    # load stl(case: already exists)
     if not force_load_merged_stl:
         stl_divided_folder_full_path_name = os.path.join(path, "divided")
         stl_divided_files_full_path_names = []
@@ -94,18 +102,20 @@ def load_submodule(path, force_load_merged_stl):
         if 0 != len(stl_divided_files_full_path_names):
             divided_shells = []
             for stl_divided_files_full_path_name in stl_divided_files_full_path_names:
-                divided_shells.append(load_binary_stl(stl_divided_files_full_path_name))
+                divided_shells.append(load_binary_stl(stl_divided_files_full_path_name, vertex_matching))
             return divided_shells
 
     file_name = path.split(os.sep)[-1]
     stl_file_full_path_name = os.path.join(path, file_name + ".stl")
     if os.path.exists(stl_file_full_path_name):
-        return [load_binary_stl(stl_file_full_path_name)]
+        return [load_binary_stl(stl_file_full_path_name, vertex_matching)]
 
+    # generating stl
     py_file_full_path_name = os.path.join(path, file_name + ".py")
     if os.path.exists(py_file_full_path_name):
         subprocess.call('python %s' % py_file_full_path_name, shell=True)
     
+    # load stl(case: generated now)
     if not force_load_merged_stl:
         stl_divided_files_full_path_names = []
         if os.path.exists(stl_divided_folder_full_path_name):
@@ -113,11 +123,11 @@ def load_submodule(path, force_load_merged_stl):
         if 0 != len(stl_divided_files_full_path_names):
             divided_shells = []
             for stl_divided_files_full_path_name in stl_divided_files_full_path_names:
-                divided_shells.append(load_binary_stl(stl_divided_files_full_path_name))
+                divided_shells.append(load_binary_stl(stl_divided_files_full_path_name, vertex_matching))
             return divided_shells
 
     if os.path.exists(stl_file_full_path_name):
-        return [load_binary_stl(stl_file_full_path_name)]
+        return [load_binary_stl(stl_file_full_path_name, vertex_matching)]
 
     raise Exception("failed to create stl")
 


### PR DESCRIPTION
## 概要

* バグ修正と機能追加

## 詳細

* 比較の実装ミスを修正
* 球の生成メソッドにバグがあったので修正
* オブジェクトの拡大縮小機能を追加
* 特定のRibでX軸、Y軸における頂点間の最大長さを取得するメソッドを追加
* STLファイルを読み込んだ際の頂点情報の持ち方のパターンを増やす
  * vertex_matching=True：同一の座標にある頂点は一つの頂点オブジェクトとして持つ、読み込み時間大
  * vertex_matching=False：(面の数)×3の頂点オブジェクトを持つ、読み込み時間小